### PR TITLE
Add int, char, float types

### DIFF
--- a/sourcepawn.JSON-tmLanguage
+++ b/sourcepawn.JSON-tmLanguage
@@ -23,7 +23,7 @@
       "name": "string.sourcePawn"
     },
     {
-      "match": "(\\b)(enum|struct|decl|new|Float|bool|String|Handle|const|Plugin|client)(\\b)",
+      "match": "(\\b)(enum|struct|int|char|float|decl|new|Float|bool|String|Handle|const|Plugin|client)(\\b)",
       "captures": {
         "2": {"name": "storage.type.SourcePawn"}
       }


### PR DESCRIPTION
New sourcemod 1.7 transitional syntax introduced the int, char, and float syntax types.

https://wiki.alliedmods.net/SourcePawn_Transitional_Syntax