### PR TITLE
Add int, char, float types

### DIFF
--- a/sourcepawn.tmLanguage
+++ b/sourcepawn.tmLanguage
@@ -54,7 +54,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(\b)(enum|struct|decl|new|Float|bool|String|Handle|const|Plugin|client)(\b)</string>
+			<string>(\b)(enum|struct|int|char|float|decl|new|Float|bool|String|Handle|const|Plugin|client)(\b)</string>
 		</dict>
 		<dict>
 			<key>match</key>


### PR DESCRIPTION
New sourcemod 1.7 transitional syntax introduced the int, char, and float syntax types.

https://wiki.alliedmods.net/SourcePawn_Transitional_Syntax