### PR TITLE
Don't highlight numbers preceeded by letters

### DIFF
--- a/sourcepawn.JSON-tmLanguage
+++ b/sourcepawn.JSON-tmLanguage
@@ -37,7 +37,7 @@
       "name": "support.function.SourcePawn"
     },
     {
-      "match": "[0-9]+",
+      "match": "\\w*(?<![a-z])[0-9]+",
       "name": "constant.numeric.SourcePawn"
     },
     {

--- a/sourcepawn.tmLanguage
+++ b/sourcepawn.tmLanguage
@@ -70,7 +70,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>[0-9]+</string>
+			<string>\w*(?&lt;![a-z])[0-9]+</string>
 			<key>name</key>
 			<string>constant.numeric.SourcePawn</string>
 		</dict>


### PR DESCRIPTION
This is likely not sufficient to cover all cases, but it should reduce the frequency of numbers erroneously receiving highlighting.

Closes #6.

![image](https://cloud.githubusercontent.com/assets/873012/20413925/32e2304e-acf5-11e6-932f-542a44aa8cd5.png)
