### PR TITLE
Highlight multiline strings

### DIFF
--- a/sourcepawn.JSON-tmLanguage
+++ b/sourcepawn.JSON-tmLanguage
@@ -15,8 +15,12 @@
       "name": "comment.block.SourcePawn"
     },
     {
-      "match": "\"(\\\\\"|\\\\.|[^\\\\\"])*\"",
-      "name": "string.SourcePawn"
+      "begin": "\"",
+      "end": "\"",
+      "name": "string.SourcePawn",
+      "patterns": [
+        {"match": "(\\\\\"|\\\\.|[^\\\\\"])*"}
+      ]
     },
     {
       "match": "'(\\\\.|[^\\\\])?'",

--- a/sourcepawn.tmLanguage
+++ b/sourcepawn.tmLanguage
@@ -34,10 +34,19 @@
 			<string>comment.block.SourcePawn</string>
 		</dict>
 		<dict>
-			<key>match</key>
-			<string>"(\\"|\\.|[^\\"])*"</string>
+			<key>begin</key>
+			<string>"</string>
+			<key>end</key>
+			<string>"</string>
 			<key>name</key>
 			<string>string.SourcePawn</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>(\\"|\\.|[^\\"])*</string>
+				</dict>
+			</array>
 		</dict>
 		<dict>
 			<key>match</key>


### PR DESCRIPTION
Same regex, but it uses begin/end to match over multiple lines. Fixes #13.